### PR TITLE
Disable version updates by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"  # See documentation for possible values
+    directory: "/"  # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0  # To only get security updates in PRs


### PR DESCRIPTION
Since we have a really simple, non-critical, application, getting lots of version updates doesn't have much value for us. Security updates on the other hand is valuable for us and we keep those.